### PR TITLE
Feature/device token plug auth

### DIFF
--- a/chat_service/config/dev.exs
+++ b/chat_service/config/dev.exs
@@ -9,6 +9,7 @@ import Config
 config :chat_service, ChatServiceWeb.Endpoint,
   # Binding to loopback ipv4 address prevents access from other machines.
   # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
+  url: [host: "localhost", port: 4000],
   http: [ip: {0, 0, 0, 0}, port: 4000],
   check_origin: false,
   code_reloader: true,

--- a/chat_service/config/runtime.exs
+++ b/chat_service/config/runtime.exs
@@ -46,7 +46,7 @@ if config_env() == :prod do
       You can generate one by calling: mix phx.gen.secret
       """
 
-  host = System.get_env("PHX_HOST") || "example.com"
+  host = System.get_env("PHX_HOST") || "localhost"
   port = String.to_integer(System.get_env("PORT") || "4000")
 
   config :chat_service, :dns_cluster_query, System.get_env("DNS_CLUSTER_QUERY")

--- a/chat_service/lib/chat_service_web/plugs/device_token_plug.ex
+++ b/chat_service/lib/chat_service_web/plugs/device_token_plug.ex
@@ -1,0 +1,25 @@
+defmodule ChatServiceWeb.DeviceTokenPlug do
+  import Plug.Conn
+  alias ChatService.Auth
+
+  def init(default), do: default
+
+  def call(conn, _opts) do
+    device_token = conn |> get_req_header("device_token") |>  List.first()
+    case device_token do
+      nil ->
+        conn
+        |> put_status(:bad_request)
+        |> halt()
+      device_token ->
+        case Auth.verify_device_token(conn.assigns[:user_id], device_token) do
+          {:ok, _message} ->
+            conn
+          {:error, _reason} ->
+            conn
+            |> put_status(:unauthorized)
+            |> halt()
+        end
+    end
+  end
+end

--- a/chat_service/lib/chat_service_web/router.ex
+++ b/chat_service/lib/chat_service_web/router.ex
@@ -4,6 +4,7 @@ defmodule ChatServiceWeb.Router do
   pipeline :api do
     plug :accepts, ["json"]
     plug ChatServiceWeb.AuthPlug
+    plug ChatServiceWeb.DeviceTokenPlug
   end
 
   scope "/api", ChatServiceWeb do

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -219,7 +219,7 @@ This document provides detailed information about the API endpoints available in
 - `500 Internal Server Error`: Server error
 
 # Chat Service Endpoints - http://localhost:4000/
-
+(IMPORTANT: add JWT token in the Authorization header Bearer token and device_token to the http header)
 ## Create Chat
 `POST /api/chat`
 ```json
@@ -256,6 +256,7 @@ This document provides detailed information about the API endpoints available in
 - `500 Internal Server Error`: Server error
 
 # Chat Service Endpoints - http://localhost:4000/
+(IMPORTANT: add JWT token in the Authorization header Bearer token and device_token to the http header)
 ## Change User Nickname
 `PATCH - /api/user/nickname`
 ```json


### PR DESCRIPTION
Now to the chat service, to acess the endpoints the client need to put `device_token` on the http Header to validate the identity of the user.