### PR TITLE
add: new device confirmation screen

### DIFF
--- a/AshChatNative/src/app/newdevice.tsx
+++ b/AshChatNative/src/app/newdevice.tsx
@@ -1,0 +1,62 @@
+import { Keyboard, Text, TextInput, TouchableWithoutFeedback, View } from "react-native";
+import { Button } from "../components/Button";
+import { useContext, useRef, useState } from "react";
+import { AuthContext } from "../contexts/auth/authContext";
+
+export default function NewDevice(){
+    const {onNewDevice} = useContext(AuthContext)
+
+    const [code, setCode] = useState(['', '', '', '', '', '']);
+    const inputs = useRef<Array<TextInput | null>>([]);
+
+    function handleChange(text: string, index: number) {
+        const newCode = [...code];
+        newCode[index] = text;
+    
+        setCode(newCode);
+    
+        // Move to the next input if a digit is entered
+        if (text && index < inputs.current.length - 1) {
+            inputs.current[index + 1]?.focus();
+        }
+    
+        // Move to the previous input if the field is empty and backspace was pressed
+        if (!text && index > 0) {
+            inputs.current[index - 1]?.focus();
+        }
+    };
+
+    async function handleConfirmNewDevice(){
+        const codeValue = code.join('');
+        try {
+            await onNewDevice(codeValue);
+        } catch (error) {
+            return
+        }
+    }
+    return (
+        <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+        <View className="flex-1 pt-[62px] items-center justify-center">
+            <View className="items-center justify-center px-[45] mb-10">
+                <Text className="text-white font-bold text-lg mb-5">Get your Code to allow new device</Text>
+                <Text className="text-white italic">Please, enter the 6 digit code that send to your email address.</Text>
+            </View>
+
+            <View className="flex-row justify-between px-5 gap-2 mb-10">
+                {code.map((digit, index) => (
+                    <TextInput
+                    key={index}
+                    ref={(input) => (inputs.current[index] = input)}
+                    className="w-12 h-12 border border-gray-300 rounded-lg text-3xl text-center bg-white"
+                    value={digit}
+                    onChangeText={(text) => handleChange(text, index)}
+                    keyboardType="number-pad"
+                    maxLength={1}
+                    />
+                ))}
+            </View>
+            <Button title="Verify and Proceed" onPress={handleConfirmNewDevice}/>
+        </View>
+        </TouchableWithoutFeedback>
+    )
+}

--- a/AshChatNative/src/contexts/auth/authModelContext.ts
+++ b/AshChatNative/src/contexts/auth/authModelContext.ts
@@ -93,4 +93,12 @@ export class AuthModelContext {
         const MMKVProfile = new MMKVStorageProfile();
         MMKVProfile.setUserProfile(data);
     }
+
+    public static async newDeviceTryingToLogin(temporatyToken: string){
+        await SecureStoragePersistence.setTemporaryToken(temporatyToken);
+    }
+
+    public static async getTemporaryToken(): Promise<string | null>{
+        return await SecureStoragePersistence.getTemporaryToken();
+    }
 }

--- a/AshChatNative/src/persistence/SecureStorage/index.ts
+++ b/AshChatNative/src/persistence/SecureStorage/index.ts
@@ -8,7 +8,8 @@ class SecureStoragePersistence {
         UNIQUEDEVICEID: "ashChat.uniqueDeviceId",
         DEVICEOS: "ashChat.deviceOS",
         USERID: "ashChat.userId",
-        NOTIFICATIONTOKEN: "ashChat.notificationToken"
+        NOTIFICATIONTOKEN: "ashChat.notificationToken",
+        TEMPORARYTOKEN: "ashChat.temporary"
     }
     static async clearTokens(){
         await SecureStore.deleteItemAsync(this.KEYS.TOKEN);
@@ -28,6 +29,14 @@ class SecureStoragePersistence {
 
     static async getJWT(): Promise<string | null>{
         return await SecureStore.getItemAsync(this.KEYS.TOKEN);
+    }
+
+    static async setTemporaryToken(value: string){
+        await SecureStore.setItemAsync(this.KEYS.TEMPORARYTOKEN, value);
+    }
+
+    static async getTemporaryToken(): Promise<string | null>{
+        return await SecureStore.getItemAsync(this.KEYS.TEMPORARYTOKEN);
     }
 
     static async setEmail(value: string){


### PR DESCRIPTION
This pull request introduces a new feature for handling the addition of a new device in the `AshChatNative` application. The changes include the implementation of a new screen for entering a verification code, updates to the authentication context to support this feature, and modifications to secure storage to handle temporary tokens.
This PR resolves the issue #23 

### New Device Verification Feature:

* [`AshChatNative/src/app/newdevice.tsx`](diffhunk://#diff-f7e10eac2daca3b4305462fcb770281a464b0dc837ded271f6ca1cd48c9e61f5R1-R62): Added a new screen component `NewDevice` for users to enter a 6-digit verification code when adding a new device.

### Authentication Context Updates:

* `AshChatNative/src/contexts/auth/authContext.tsx`:
  * Added `onNewDevice` method to the `AuthProps` interface and implemented the method in `AuthContextProvider`. [[1]](diffhunk://#diff-c449bde86359d8fe67eeb25ae42724d197961a13164b389a305f58e68bc8670bR18) [[2]](diffhunk://#diff-c449bde86359d8fe67eeb25ae42724d197961a13164b389a305f58e68bc8670bR172-R205)
  * Modified the login error handling to prompt for new device verification and navigate to the new device screen.
  * Updated the context provider to include the new `onNewDevice` method.

### Secure Storage Enhancements:

* `AshChatNative/src/persistence/SecureStorage/index.ts`:
  * Added methods to set and get a temporary token for new device verification. [[1]](diffhunk://#diff-4af600e97b847e9a85ae5f9e71c7a5d01a49792dc08e9e1be4e5f84ba940dd7fL11-R12) [[2]](diffhunk://#diff-4af600e97b847e9a85ae5f9e71c7a5d01a49792dc08e9e1be4e5f84ba940dd7fR34-R41)

### Auth Model Context Updates:

* [`AshChatNative/src/contexts/auth/authModelContext.ts`](diffhunk://#diff-3d13db7c9e0ac53d6d189bccd2faafbe6c1533aea94cdfcc4062a2101de668c6R96-R103): Added methods to handle the storage and retrieval of temporary tokens for new device verification.